### PR TITLE
Create Sherpa Action to filter redundant FP transitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .env
 venv/
 .vscode/
+
+.files/
+*.png

--- a/actions/EventDrivenFilterTransitionsAction.py
+++ b/actions/EventDrivenFilterTransitionsAction.py
@@ -1,0 +1,99 @@
+import re
+from sherpa_ai.actions.base import BaseAction
+from util import call_gpt4, remove_transitions_from_exit_transition_table, extract_table_entries, create_exit_transitions_table, find_events_for_transitions_table, merge_tables
+
+class EventDrivenFilterTransitionsAction(BaseAction):
+    name: str = "event_driven_filter_transitions_action"
+    args: dict = {}
+    usage: str = "Given a description of a system and the identified transitions of the system, reduce the number of inaccurate or unneccesary transitions in the UML State Machine"
+    description: str = ""
+
+    
+    def send_filter_transitions_prompt(self, system_name, transitions_table, events, state):
+        events_formatted = ", ".join(events)
+        prompt = f"""
+        You are an AI assistant specialized in designing UML state machines from a textual description of a system. Given the description of the system, a state, and a table containing the transitions exiting the provided state, your task is to answer a question answering task.
+        
+        Name of the system:
+        {system_name}
+
+        Description of the system:
+        {self.description}
+
+        The identified state is:
+        {state}
+
+        The table of identified transitions exiting the state is:
+        {transitions_table}
+
+        The events associated with the transitions are:
+        {events_formatted}
+
+        Solution structure:
+        1. Begin the response with "Let's think step by step."
+        2. Examine the events and transitions that are exiting the current state.
+        3. Examine the description of the system. Using the description of the system, determine partial orderings of the events related to the transitions. A partial ordering of events refers to a system where some events must occur in a specific sequence due to dependencies, while others can happen independently or concurrently.
+        4. Based on the partial orderings which you generate and the provided state, identify the transitions that violate the partial orderings. In other words, based on the state and the partial orderings which you have generated, identify the transitions that CANNOT occur for the given state.
+        5. If there are transitions to remove based on the partial orderings. Output "NO TRANSITIONS REMOVED".
+        6. Otherwise, if transitions need to be removed, output the IDs of the transitions, as indicated in the "Transition ID" column, in a comma separated list in the following format:
+
+        Transitions Removed: <first_id>, <second_id>, <third_id>, ...
+
+        The IDs that you provide should come from the original transitions table provided to you above. DO NOT add transition IDs that do not exist.
+        Your solution MUST be in the above format, otherwise it will be rejected.
+        """
+
+        response = call_gpt4(prompt=prompt,
+                             temperature=0.7)
+        
+        match = re.search(r"Transitions Removed:\s*([\w\s,]+)", response)
+        
+        if "NO TRANSITIONS REMOVED" in response:
+            print("No transitions removed")
+            transitions_table = remove_transitions_from_exit_transition_table(transitions_table, set())
+            return transitions_table
+        else:
+            if match:
+                # extract either a comma separated list or a single ID provided by the LLM
+                ids_to_remove_str = match.group(1)
+                ids_to_remove = [id.strip() for id in ids_to_remove_str.split(",") if id.strip()]
+                updated_transitions = remove_transitions_from_exit_transition_table(transitions_table=transitions_table,
+                                                                                    ids_to_remove=ids_to_remove)
+                print(f"Removed transitions {ids_to_remove}")
+                return updated_transitions
+            else:
+                print(f"Match not found. Response: {response}")
+                transitions_table = remove_transitions_from_exit_transition_table(transitions_table, set())
+                return transitions_table
+        
+
+    def execute(self):
+        print(f"Running {self.name}...")
+        system_name = self.belief.get("event_driven_system_name_search_action", "Thermomix TM6")
+
+        event_driven_transitions_table = self.belief.get("event_driven_create_transitions_action")
+        event_driven_states_table = self.belief.get("event_driven_state_search_action")
+        states = extract_table_entries(table=event_driven_states_table)
+
+        filtered_transitions_tables = []
+
+        # create partial orders based on the transitions that exit each state 
+        for state in states:
+            exit_transitions = create_exit_transitions_table(transitions_table=event_driven_transitions_table,
+                                                                   from_state=state)
+            
+            events = find_events_for_transitions_table(transitions_table=exit_transitions)
+            
+            filtered_transitions_table = self.send_filter_transitions_prompt(system_name=system_name,
+                                                                             transitions_table=exit_transitions, 
+                                                                             events=events, 
+                                                                             state=state)
+            
+            filtered_transitions_tables.append(filtered_transitions_table)
+        
+        filtered_transitions_table = merge_tables(html_tables_list=filtered_transitions_tables)
+
+        print(filtered_transitions_table)
+        return filtered_transitions_table
+                
+

--- a/event_driven_smf.py
+++ b/event_driven_smf.py
@@ -15,6 +15,7 @@ from actions.EventDrivenCreateHierarchicalStatesAction import EventDrivenCreateH
 from actions.EventDrivenHierarchicalInitialStateSearchAction import EventDrivenHierarchicalInitialStateSearchAction
 from actions.EventDrivenRefactorTransitionNamesAction import EventDrivenRefactorTransitionNamesAction
 from actions.EventDrivenDisplayResultsAction import EventDrivenDisplayResultsAction
+from actions.EventDrivenFilterTransitionsAction import EventDrivenFilterTransitionsAction
 from event_driven_smf_transitions import transitions
 
 description = """
@@ -58,6 +59,8 @@ event_driven_event_search_action = EventDrivenEventSearchAction(belief=belief,
                                                                 description=description)
 event_driven_create_transitions_action = EventDrivenCreateTransitionsAction(belief=belief,
                                                                             description=description)
+event_driven_filter_transitions_action = EventDrivenFilterTransitionsAction(belief=belief,
+                                                                            description=description)
 event_driven_create_hierarchical_states_action = EventDrivenCreateHierarchicalStatesAction(belief=belief,
                                                                                            description=description)
 event_driven_hierarchical_initial_state_search_action = EventDrivenHierarchicalInitialStateSearchAction(belief=belief,
@@ -73,6 +76,7 @@ event_driven_action_map = {
     event_driven_initial_state_search_action.name: event_driven_initial_state_search_action,
     event_driven_event_search_action.name: event_driven_event_search_action,
     event_driven_create_transitions_action.name: event_driven_create_transitions_action,
+    event_driven_filter_transitions_action.name: event_driven_filter_transitions_action,
     event_driven_create_hierarchical_states_action.name: event_driven_create_hierarchical_states_action,
     event_driven_hierarchical_initial_state_search_action.name: event_driven_hierarchical_initial_state_search_action,
     event_driven_refactor_transition_names_action.name: event_driven_refactor_transition_names_action,
@@ -85,6 +89,7 @@ states = [
             "InitialStateSearch",
             "EventSearch",
             "CreateTransitions",
+            "FilterTransitions",
             "CreateHierarchicalStates",
             "HierarchicalInitialStateSearch",
             "RefactorTransitionNames",
@@ -93,7 +98,7 @@ states = [
          ]
 
 # create event driven state macine
-initial = "SystemNameSearch"
+initial = "FilterTransitions"
 event_driven_smf = SherpaStateMachine(states=states, 
                                       transitions=transitions, 
                                       initial=initial, 

--- a/event_driven_smf_transitions.py
+++ b/event_driven_smf_transitions.py
@@ -29,8 +29,15 @@ event_search = {
 create_transitions = {
     "trigger": "start_event_driven_create_transitions",
     "source": "CreateTransitions",
-    "dest": "CreateHierarchicalStates",
+    "dest": "FilterTransitions",
     "before": "event_driven_create_transitions_action"
+}
+
+filter_transitions = {
+    "trigger": "start_event_driven_filter_transitions",
+    "source": "FilterTransitions",
+    "dest": "CreateHierarchicalStates",
+    "before": "event_driven_filter_transitions_action"
 }
 
 create_hierarchical_states = {
@@ -67,6 +74,7 @@ transitions = [
                 initial_state_search,
                 event_search,
                 create_transitions,
+                filter_transitions,
                 create_hierarchical_states,
                 hierarchical_initial_state_search,
                 refactor_transition_names,

--- a/util.py
+++ b/util.py
@@ -265,7 +265,7 @@ def merge_tables(html_tables_list) -> Tag:
     # Return the <table> Tag object directly
     return merged_table
 
-def create_from_state_transitions_table(transitions_table, from_state):
+def create_exit_transitions_table(transitions_table, from_state):
     # Parse the transitions table
     transitions_table = str(transitions_table)
     soup = BeautifulSoup(transitions_table, "html.parser")

--- a/util.py
+++ b/util.py
@@ -256,6 +256,26 @@ def merge_tables(html_tables_list) -> Tag:
     # Return the <table> Tag object directly
     return merged_table
 
+def create_from_state_transitions_table(transitions_table, from_state):
+    transitions_table = str(transitions_table)
+    soup = BeautifulSoup(transitions_table, "html.parser")
+    transitions_table = soup.find("table")
+
+    rows = transitions_table.find_all("tr")
+
+    from_state_transitions_table = BeautifulSoup("<table border='1'></table>", "html.parser")
+    from_state_transitions_table_table = from_state_transitions_table.table
+
+    from_state_transitions_table_table.append(rows[0])
+
+    for row in rows[1:]:
+        columns = row.find_all("td")
+        if columns[0].get_text(strip=True) == from_state:
+            from_state_transitions_table_table.append(row)
+
+    return from_state_transitions_table
+
+
 def group_parent_child_states(hierarchical_state_table):
     if isinstance(hierarchical_state_table, str):
         soup = BeautifulSoup(hierarchical_state_table, "html.parser")

--- a/util.py
+++ b/util.py
@@ -222,6 +222,12 @@ def extract_event_driven_events_table(llm_response : str) -> Tag:
                                                             headers=event_driven_events_table_headers)
     return event_driven_events_table
 
+def extract_event_driven_partial_order_table(llm_response: str) -> Tag:
+    event_driven_partial_order_headers = ["Partial Order Index", "Partial Order"]
+    event_drivent_partial_order_table = extract_table_using_headers(llm_response=llm_response,
+                                                                    headers=event_driven_partial_order_headers)
+    return event_drivent_partial_order_table
+
 def extract_table_entries(table: Tag):
     entries = [td.get_text(strip=True) for td in table.find_all("td")]
     return entries
@@ -323,7 +329,6 @@ def map_child_state_to_parent_state(hierarchical_state_table):
     return child_to_parent_dict
 
 def refactor_transition_table_with_parent_states(transitions_table, hierarchical_state_table):
-
     # map each child state to its parent, if it has one
     child_to_parent_dict = map_child_state_to_parent_state(hierarchical_state_table=hierarchical_state_table)
 
@@ -359,4 +364,24 @@ def refactor_transition_table_with_parent_states(transitions_table, hierarchical
         cells[1].string = formatted_to_state
 
     return transitions_table
+
+def find_events_for_transitions_table(transitions_table):
+    # convert to beautiful soup if input is a string
+    transitions_table = str(transitions_table)
+    soup = BeautifulSoup(transitions_table, "html.parser")
+    transitions_table = soup.find("table")
+
+    # iterate over each row in the transitions table
+    rows = transitions_table.find_all("tr")[1:]
+
+    events = set()
+
+    for row in rows:
+        cells = row.find_all("td")
+        event = cells[2].get_text(strip=True)
+        events.add(event)
+
+    return list(events)
+
+
     


### PR DESCRIPTION
Summary:

I ran this filtering action on the transitions results that I showed to Gunter last meeting. Here's what I found:

- increased F-Score by `0.2`(!!!) for Transitions from `0.36` to `0.55`
- recall for Transitions was `0.8235`
- an F-Score of `0.55` is still low, but this is largely due to the poor performing prompt that I made for identifying states. using a 1-shot prompt would likely boost the F-Score
- F-Score of `0.4` for Guards
- F-Score of `0.45` for Actions, and a recall of `0.8333`

closes #22 