### PR TITLE
Fix Dot Notation for Superstates/Substates for Event Based SMF

### DIFF
--- a/backend/event_driven_smf/actions/EventDrivenFactorOutTransitionsForHierarchalStates.py
+++ b/backend/event_driven_smf/actions/EventDrivenFactorOutTransitionsForHierarchalStates.py
@@ -12,7 +12,7 @@ class EventDrivenFactorOutTransitionsForHierarchalStates(BaseAction):
     def execute(self):
         print(f"Running {self.name}...")
 
-        event_driven_transitions = str(self.belief.get("event_driven_refactor_transition_names_action"))
+        event_driven_transitions = str(self.belief.get("event_driven_create_transitions_action"))
         state_hierarchy = str(self.belief.get("event_driven_create_hierarchical_states_action"))
 
         transitions_list = parse_html_table(event_driven_transitions)
@@ -56,7 +56,7 @@ def factor_transitions(transitions, hierarchy):
                 modified_transitions = [
                     t for t in modified_transitions if not (
                         t['FromState'] in substates_set and
-                        t['To State'] == key[0] and
+                        t['ToState'] == key[0] and
                         t['Event'] == key[1] and
                         t['Guard'] == key[2] and
                         t['Action'] == key[3]

--- a/backend/event_driven_smf/actions/EventDrivenHierarchicalInitialStateSearchAction.py
+++ b/backend/event_driven_smf/actions/EventDrivenHierarchicalInitialStateSearchAction.py
@@ -66,6 +66,8 @@ Remember, your expertise in UML state machines is crucial for creating an accura
             superstate_initial_state = "NOT FOUND"
         print(superstate_initial_state)
 
+        return superstate_initial_state
+
 
     def execute(self):
         """

--- a/backend/event_driven_smf/actions/EventDrivenHierarchicalInitialStateSearchAction.py
+++ b/backend/event_driven_smf/actions/EventDrivenHierarchicalInitialStateSearchAction.py
@@ -63,7 +63,7 @@ Remember, your expertise in UML state machines is crucial for creating an accura
         superstate_initial_state_search = re.search(r"<superstate_initial_state>(.*?)</superstate_initial_state>", response)
 
         if superstate_initial_state_search:
-            superstate_initial_state = superstate_initial_state_search.group(1)
+            superstate_initial_state = superstate_initial_state_search.group(1).strip('\'"')
         else:
             superstate_initial_state = "NOT FOUND"
         print(superstate_initial_state)

--- a/backend/event_driven_smf/event_driven_smf.py
+++ b/backend/event_driven_smf/event_driven_smf.py
@@ -142,7 +142,7 @@ def run_event_driven_smf():
                 hierarchical_states_table = belief.get("event_driven_create_hierarchical_states_action")
                 transitions_table = belief.get("event_driven_history_state_search_action")
                 parallel_state_table = None
-                initial_state = belief.get("event_driven_initial_state_search_action").replace(' ', '')
+                initial_state = belief.get("event_driven_initial_state_search_action")
                 hierarchical_initial_states = belief.get("event_driven_hierarchical_initial_state_search")
 
                 create_event_based_gsm_diagram(hierarchical_states_table=hierarchical_states_table,

--- a/backend/event_driven_smf/event_driven_smf.py
+++ b/backend/event_driven_smf/event_driven_smf.py
@@ -28,11 +28,11 @@ from actions.EventDrivenHistoryStateSearchAction import EventDrivenHistoryStateS
 from actions.EventDrivenFactorOutTransitionsForHierarchalStates import EventDrivenFactorOutTransitionsForHierarchalStates
 from actions.EventDrivenParallelRegionsSearchAction import EventDrivenParallelRegionsSearchAction
 from event_driven_smf_transitions import transitions
-from resources.state_machine_descriptions import spa_manager_winter_2018
+from resources.state_machine_descriptions import thermomix_fall_2021
 from resources.util import create_event_based_gsm_diagram
 import time
 
-description = spa_manager_winter_2018
+description = thermomix_fall_2021
 
 belief = Belief()
 belief.set("description", description)

--- a/backend/event_driven_smf/event_driven_smf.py
+++ b/backend/event_driven_smf/event_driven_smf.py
@@ -138,11 +138,13 @@ def run_event_driven_smf():
                 transitions_table = belief.get("event_driven_history_state_search_action")
                 parallel_state_table = None
                 initial_state = belief.get("event_driven_initial_state_search_action").replace(' ', '')
+                hierarchical_initial_states = belief.get("event_driven_hierarchical_initial_state_search")
 
                 create_event_based_gsm_diagram(hierarchical_states_table=hierarchical_states_table,
                                                transitions_table=transitions_table,
                                                parallel_state_table=parallel_state_table,
-                                               initial_state=initial_state)
+                                               initial_state=initial_state,
+                                               hierarchical_initial_states=hierarchical_initial_states)
                 
 
             finally:

--- a/backend/event_driven_smf/event_driven_smf_transitions.py
+++ b/backend/event_driven_smf/event_driven_smf_transitions.py
@@ -66,19 +66,11 @@ create_hierarchical_states = {
 hierarchical_initial_state_search = {
     "trigger": "start_event_driven_hierarchical_initial_state_search",
     "source": "HierarchicalInitialStateSearch",
-    "dest": "RefactorTransitionNames",
+    "dest": "FactorOutHierarchalTransitions",
     "before": "event_driven_hierarchical_initial_state_search"
 }
 
-# step 10: rename the states in the transitions table using ParentState.ChildState notation using EventDrivenRefactorTransitionNamesAction
-refactor_transition_names = {
-    "trigger": "start_event_driven_refactor_transition_names",
-    "source": "RefactorTransitionNames",
-    "dest": "FactorOutHierarchalTransitions",
-    "before": "event_driven_refactor_transition_names_action"
-}
-
-# step 11: move common transitions amongst children states to parent state
+# step 10: move common transitions amongst children states to parent state
 factor_out_hierarchal_transitions = {
     "trigger": "start_event_driven_factor_out_transitions_for_hierarchal_states",
     "source": "FactorOutHierarchalTransitions",
@@ -86,7 +78,7 @@ factor_out_hierarchal_transitions = {
     "before": "event_driven_factor_out_transitions_for_hierarchal_states_action"
 }
 
-# step 12: identify necessary history states in the UML State Machine using EventDrivenHistoryStateSearchAction
+# step 11: identify necessary history states in the UML State Machine using EventDrivenHistoryStateSearchAction
 history_state_search = {
     "trigger": "start_event_driven_history_state_search_action",
     "source": "HistoryStateSearch",
@@ -94,7 +86,7 @@ history_state_search = {
     "before": "event_driven_history_state_search_action"
 }
 
-# step 13: print the final tables representing the UML State Machine
+# step 12: print the final tables representing the UML State Machine
 display_results = {
     "trigger": "start_event_driven_display_results_action",
     "source": "DisplayResults",
@@ -111,7 +103,6 @@ transitions = [
                 create_transitions,
                 create_hierarchical_states,
                 hierarchical_initial_state_search,
-                refactor_transition_names,
                 factor_out_hierarchal_transitions,
                 history_state_search,
                 display_results

--- a/backend/resources/util.py
+++ b/backend/resources/util.py
@@ -269,7 +269,7 @@ def gsm_tables_to_dict(hierarchical_states_table : Tag, transitions_table : Tag,
         states.remove(non_composite_state[0])
 
     # remove states which are already encompassed by a parent state
-    states = [state for state in states if not non_composite_state or state in non_composite_state[0]["children"] or isinstance(state, dict)]
+    states = [state for state in states if (non_composite_state and state in non_composite_state[0]["children"]) or isinstance(state, dict)]
 
     # Remove all spaces not to confuse mermaid
     states = list(map(state_remove_spaces, states))
@@ -280,7 +280,7 @@ def gsm_tables_to_dict(hierarchical_states_table : Tag, transitions_table : Tag,
 
 
 
-def create_event_based_gsm_diagram(hierarchical_states_table : Tag, transitions_table : Tag, parallel_state_table : Tag, initial_state : str):
+def create_event_based_gsm_diagram(hierarchical_states_table : Tag, transitions_table : Tag, parallel_state_table : Tag, initial_state : str, hierarchical_initial_states : dict):
     gsm_states, gsm_transitions, gsm_parallel_regions = gsm_tables_to_dict(hierarchical_states_table=hierarchical_states_table,
                                                                            transitions_table=transitions_table,
                                                                            parallel_state_table=parallel_state_table)

--- a/backend/resources/util.py
+++ b/backend/resources/util.py
@@ -269,7 +269,7 @@ def gsm_tables_to_dict(hierarchical_states_table : Tag, transitions_table : Tag,
         states.remove(non_composite_state[0])
 
     # remove states which are already encompassed by a parent state
-    states = [state for state in states if not non_composite_state or state in non_composite_state[0]["children"] or isinstance(state, dict)]
+    states = [state for state in states if (non_composite_state and state in non_composite_state[0]["children"]) or isinstance(state, dict)]
 
     # Remove all spaces not to confuse mermaid
     states = list(map(state_remove_spaces, states))

--- a/backend/resources/util.py
+++ b/backend/resources/util.py
@@ -278,12 +278,33 @@ def gsm_tables_to_dict(hierarchical_states_table : Tag, transitions_table : Tag,
 
     return states, transitions, parallel_regions
 
+def add_initial_hierarchical_states(gsm_states : list, hierarchical_initial_states : dict):
+    """
+    the add_initial_hierarchical_states sets the "initial" key of the hierarchical states in the gsm_states
+    list to map to the name of the hierarchical state's initial state, as required by pytransitions. note
+    that the initial state name does NOT need to be in the format "ParentState_ChildState"
+    """
 
+    # iterate over each hierarchical state and its initial state
+    for hierarchical_state_name, initial_state_name in hierarchical_initial_states.items():
+        if initial_state_name is not None:
+            # locate the hierarchical state in the list of initial states
+            for gsm_state in gsm_states:
+                # check to see if the current state is the hierarchical state and set the initial state if it is one of the child states
+                if isinstance(gsm_state, dict) and gsm_state.get("name") == hierarchical_state_name.replace(" ", "") and initial_state_name.replace(" ", "") in gsm_state.get("children"):
+                    gsm_state["initial"] = initial_state_name.replace(" ", "")
+                    break
+
+    return gsm_states
 
 def create_event_based_gsm_diagram(hierarchical_states_table : Tag, transitions_table : Tag, parallel_state_table : Tag, initial_state : str, hierarchical_initial_states : dict):
     gsm_states, gsm_transitions, gsm_parallel_regions = gsm_tables_to_dict(hierarchical_states_table=hierarchical_states_table,
                                                                            transitions_table=transitions_table,
                                                                            parallel_state_table=parallel_state_table)
+    
+    # update the states so each hierarchical state contains their initial state
+    gsm_states = add_initial_hierarchical_states(gsm_states=gsm_states,
+                                                 hierarchical_initial_states=hierarchical_initial_states)
     print(f"States: {gsm_states}")
     print(f"Transitions: {gsm_transitions}")
     print(f"Parallel Regions: {gsm_parallel_regions}")


### PR DESCRIPTION
This turned out to be a little bit more than just removing an action :(

`pytransitions` expects that states are named `parentstate_childstate` in the list of transitions when generating the diagram. i added this fix for the Event Based SMF

closes #58 