### PR TITLE
Ensure Mermaid Diagram Accounts for Initial States of Superstates

### DIFF
--- a/backend/event_driven_smf/actions/EventDrivenHierarchicalInitialStateSearchAction.py
+++ b/backend/event_driven_smf/actions/EventDrivenHierarchicalInitialStateSearchAction.py
@@ -66,6 +66,8 @@ Remember, your expertise in UML state machines is crucial for creating an accura
             superstate_initial_state = "NOT FOUND"
         print(superstate_initial_state)
 
+        return superstate_initial_state
+
 
     def execute(self):
         """

--- a/backend/event_driven_smf/actions/EventDrivenHierarchicalInitialStateSearchAction.py
+++ b/backend/event_driven_smf/actions/EventDrivenHierarchicalInitialStateSearchAction.py
@@ -63,7 +63,7 @@ Remember, your expertise in UML state machines is crucial for creating an accura
         superstate_initial_state_search = re.search(r"<superstate_initial_state>(.*?)</superstate_initial_state>", response)
 
         if superstate_initial_state_search:
-            superstate_initial_state = superstate_initial_state_search.group(1)
+            superstate_initial_state = superstate_initial_state_search.group(1).strip('\'"')
         else:
             superstate_initial_state = "NOT FOUND"
         print(superstate_initial_state)

--- a/backend/event_driven_smf/event_driven_smf.py
+++ b/backend/event_driven_smf/event_driven_smf.py
@@ -142,7 +142,7 @@ def run_event_driven_smf():
                 hierarchical_states_table = belief.get("event_driven_create_hierarchical_states_action")
                 transitions_table = belief.get("event_driven_history_state_search_action")
                 parallel_state_table = None
-                initial_state = belief.get("event_driven_initial_state_search_action").replace(' ', '')
+                initial_state = belief.get("event_driven_initial_state_search_action")
                 hierarchical_initial_states = belief.get("event_driven_hierarchical_initial_state_search")
 
                 create_event_based_gsm_diagram(hierarchical_states_table=hierarchical_states_table,

--- a/backend/event_driven_smf/event_driven_smf.py
+++ b/backend/event_driven_smf/event_driven_smf.py
@@ -138,11 +138,13 @@ def run_event_driven_smf():
                 transitions_table = belief.get("event_driven_history_state_search_action")
                 parallel_state_table = None
                 initial_state = belief.get("event_driven_initial_state_search_action").replace(' ', '')
+                hierarchical_initial_states = belief.get("event_driven_hierarchical_initial_state_search")
 
                 create_event_based_gsm_diagram(hierarchical_states_table=hierarchical_states_table,
                                                transitions_table=transitions_table,
                                                parallel_state_table=parallel_state_table,
-                                               initial_state=initial_state)
+                                               initial_state=initial_state,
+                                               hierarchical_initial_states=hierarchical_initial_states)
                 
 
             finally:

--- a/backend/resources/util.py
+++ b/backend/resources/util.py
@@ -269,7 +269,7 @@ def gsm_tables_to_dict(hierarchical_states_table : Tag, transitions_table : Tag,
         states.remove(non_composite_state[0])
 
     # remove states which are already encompassed by a parent state
-    states = [state for state in states if not non_composite_state or state in non_composite_state[0]["children"] or isinstance(state, dict)]
+    states = [state for state in states if (non_composite_state and state in non_composite_state[0]["children"]) or isinstance(state, dict)]
 
     # Remove all spaces not to confuse mermaid
     states = list(map(state_remove_spaces, states))
@@ -280,7 +280,7 @@ def gsm_tables_to_dict(hierarchical_states_table : Tag, transitions_table : Tag,
 
 
 
-def create_event_based_gsm_diagram(hierarchical_states_table : Tag, transitions_table : Tag, parallel_state_table : Tag, initial_state : str):
+def create_event_based_gsm_diagram(hierarchical_states_table : Tag, transitions_table : Tag, parallel_state_table : Tag, initial_state : str, hierarchical_initial_states : dict):
     gsm_states, gsm_transitions, gsm_parallel_regions = gsm_tables_to_dict(hierarchical_states_table=hierarchical_states_table,
                                                                            transitions_table=transitions_table,
                                                                            parallel_state_table=parallel_state_table)

--- a/backend/resources/util.py
+++ b/backend/resources/util.py
@@ -278,12 +278,33 @@ def gsm_tables_to_dict(hierarchical_states_table : Tag, transitions_table : Tag,
 
     return states, transitions, parallel_regions
 
+def add_initial_hierarchical_states(gsm_states : list, hierarchical_initial_states : dict):
+    """
+    the add_initial_hierarchical_states sets the "initial" key of the hierarchical states in the gsm_states
+    list to map to the name of the hierarchical state's initial state, as required by pytransitions. note
+    that the initial state name does NOT need to be in the format "ParentState_ChildState"
+    """
 
+    # iterate over each hierarchical state and its initial state
+    for hierarchical_state_name, initial_state_name in hierarchical_initial_states.items():
+        if initial_state_name is not None:
+            # locate the hierarchical state in the list of initial states
+            for gsm_state in gsm_states:
+                # check to see if the current state is the hierarchical state and set the initial state if it is one of the child states
+                if isinstance(gsm_state, dict) and gsm_state.get("name") == hierarchical_state_name.replace(" ", "") and initial_state_name.replace(" ", "") in gsm_state.get("children"):
+                    gsm_state["initial"] = initial_state_name.replace(" ", "")
+                    break
+
+    return gsm_states
 
 def create_event_based_gsm_diagram(hierarchical_states_table : Tag, transitions_table : Tag, parallel_state_table : Tag, initial_state : str, hierarchical_initial_states : dict):
     gsm_states, gsm_transitions, gsm_parallel_regions = gsm_tables_to_dict(hierarchical_states_table=hierarchical_states_table,
                                                                            transitions_table=transitions_table,
                                                                            parallel_state_table=parallel_state_table)
+    
+    # update the states so each hierarchical state contains their initial state
+    gsm_states = add_initial_hierarchical_states(gsm_states=gsm_states,
+                                                 hierarchical_initial_states=hierarchical_initial_states)
     print(f"States: {gsm_states}")
     print(f"Transitions: {gsm_transitions}")
     print(f"Parallel Regions: {gsm_parallel_regions}")


### PR DESCRIPTION
The initial state of each Hierarchical State found using the `EventDrivenHierarchicalInitialStateSearchAction` are now rendered in the GSM Mermaid Diagram. If no initial state is identified by the LLM for a hierarchical state, then no initial state is created

![image](https://github.com/user-attachments/assets/6d4ebd92-1464-4ddd-8095-7cbade399256)


closes #57 